### PR TITLE
No "first()" method on Iterator

### DIFF
--- a/docs/beginner/tutorial2-surface/README.md
+++ b/docs/beginner/tutorial2-surface/README.md
@@ -80,7 +80,7 @@ let adapter = instance
         // Check if this adapter supports our surface
         surface.get_preferred_format(&adapter).is_some()
     })
-    .first()
+    .next()
     .unwrap()
 ```
 


### PR DESCRIPTION
As far as I can tell looking at the docs, there is no "first" method for the Iterator trait, but I believe "next" accomplishes getting the first item in this instance.